### PR TITLE
Add evalInList function with elem keyword for list element evaluation

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,7 +3,7 @@ name: PR Build
 on:
   pull_request:
     branches:
-      - main  # adjust if your default branch is different
+      - master  # adjust if your default branch is different
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.11.0]
+
+### Added
+- **New `evalInList` function**: Added a new function to evaluate predicates over list elements
+  - Syntax: `evalInList('listName', predicate)`
+  - Returns `true` if any element in the list matches the predicate, `false` otherwise
+  - Example: `evalInList('blacklist', elem.field1 = 'test')`
+  
+- **New `elem` keyword**: Added a reserved keyword for referencing the current list element within `evalInList` predicates
+  - Use `elem` to reference the current list item being evaluated
+  - Use `elem.field1` to access properties of the current list item
+  - Supports nested properties: `elem.field1.field2`
+  - Example: `evalInList('users', elem.status = 'active' AND elem.score > 100)`
+
+### Technical Details
+- Added `EvalInListContextEvaluator` to handle the evaluation logic
+- Implemented `ScopedVisitor` to provide scoped context for `elem` resolution within predicates
+- Updated grammar (`RuleFlowLanguage.g4`) to support `evalInList` expression and `elem` keyword
+- Added comprehensive test coverage with 17 test cases covering various scenarios:
+  - Basic matching and non-matching cases
+  - Nested property access
+  - Comparison operators (equals, not equals, greater than, less than, etc.)
+  - Logical operators (AND, OR)
+  - String operations (contains)
+  - Numeric comparisons
+  - Edge cases (empty lists, missing lists)
+  - Parent context access within predicates
+
+### Changed
+- Updated `ValidPropertyContextEvaluator` to handle `K_ELEM` tokens in property paths
+- Modified visitor dispatch to properly handle `PropertyContext` and `ValidPropertyContext` in scoped contexts
+
+## [0.10.2] - Previous Release
+- Existing functionality
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.gatekeeperx</groupId>
     <artifactId>ruleflow</artifactId>
     <name>ruleflow</name>
-    <version>0.10.2</version>
+    <version>0.11.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/antlr4/RuleFlowLanguage.g4
+++ b/src/main/antlr4/RuleFlowLanguage.g4
@@ -60,6 +60,7 @@ expr: L_PAREN expr R_PAREN                                                      
     | dateExpr                                                                  #dateOperation
     | op = REGEX_STRIP L_PAREN value = validProperty COMMA regex = SQUOTA_STRING R_PAREN                       #regexlike
     | op=ABS L_PAREN left=expr R_PAREN                                          #unary
+    | op=K_EVAL_IN_LIST L_PAREN listName=string_literal COMMA predicate=expr R_PAREN   #evalInList
     | left=expr op=K_AND right=expr                                             #binaryAnd
     | left=expr op=K_OR right=expr                                              #binaryOr
     | dateParse #dateParseExpr
@@ -109,8 +110,8 @@ dateValue: string_literal | validProperty | K_NOW L_PAREN R_PAREN;
 
 timeUnit: DAY | HOUR | MINUTE;
 
-validProperty: root=DOT? property=ID
-             | root=DOT? nestedProperty=ID (DOT ID)+;
+validProperty: root=DOT? property=(ID | K_ELEM)
+             | root=DOT? nestedProperty=(ID | K_ELEM) (DOT (ID | K_ELEM))+;
 
 DOT: '.';
 COMMA: ',';
@@ -136,6 +137,8 @@ REGEX_STRIP: 'regex_strip' | 'regexStrip' | 'regexstrip';
 MODULO: '%' | 'mod';
 K_STARTS_WITH: 'starts_with' | 'startswith' | 'startsWith';
 K_LIST: 'list';
+K_ELEM: 'elem';
+K_EVAL_IN_LIST: 'evalInList' | 'evalinlist' | 'eval_in_list';
 L_BRACE: '{';
 R_BRACE: '}';
 L_PAREN: '(';

--- a/src/main/java/com/gatekeeperx/ruleflow/evaluators/DateValueContextEvaluator.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/evaluators/DateValueContextEvaluator.java
@@ -17,8 +17,7 @@ public class DateValueContextEvaluator implements ContextEvaluator<DateValueCont
             logger.debug("DateValue: {}", zonedDateTime);
             return zonedDateTime;
         } else if(ctx.validProperty() != null) {
-            String value = (String) new ValidPropertyContextEvaluator().evaluate(
-                ctx.validProperty(), visitor);
+            Object value = visitor.visit(ctx.validProperty());
             ZonedDateTime zonedDateTime = DateTimeUtils.toZonedDateTime(value);
             logger.debug("DateValue: {}", zonedDateTime);
             return zonedDateTime;

--- a/src/main/java/com/gatekeeperx/ruleflow/evaluators/EvalInListContextEvaluator.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/evaluators/EvalInListContextEvaluator.java
@@ -1,0 +1,218 @@
+package com.gatekeeperx.ruleflow.evaluators;
+
+import com.gatekeeperx.ruleflow.RuleFlowLanguageParser;
+import com.gatekeeperx.ruleflow.errors.PropertyNotFoundException;
+import com.gatekeeperx.ruleflow.errors.UnexpectedSymbolException;
+import com.gatekeeperx.ruleflow.visitors.Visitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class EvalInListContextEvaluator implements ContextEvaluator<RuleFlowLanguageParser.EvalInListContext> {
+    private static final Logger logger = LoggerFactory.getLogger(EvalInListContextEvaluator.class);
+
+    @Override
+    public Object evaluate(RuleFlowLanguageParser.EvalInListContext ctx, Visitor visitor)
+        throws PropertyNotFoundException, UnexpectedSymbolException {
+        
+        // Extract list name from string literal
+        String listName = stripQuotes(ctx.listName.getText());
+        
+        // Get the list from visitor
+        List<?> list = visitor.getLists().get(listName);
+        if (list == null) {
+            logger.warn("List '{}' not found", listName);
+            return false;
+        }
+
+        // Evaluate predicate for each item in the list
+        // Return true if any item matches the predicate
+        boolean result = list.stream().anyMatch(item -> {
+            try {
+                // Create a scoped visitor where the current item is the data context
+                // This allows elem.field1 to access field1 from the current item
+                ScopedVisitor scopedVisitor = new ScopedVisitor(item, visitor);
+                Object predicateResult = scopedVisitor.visit(ctx.predicate);
+                boolean match = predicateResult instanceof Boolean && (Boolean) predicateResult;
+                logger.debug("EvalInList predicate evaluation: item={}, result={}, match={}", item, predicateResult, match);
+                return match;
+            } catch (Exception e) {
+                logger.warn("Error evaluating predicate for list item {}: {}", item, e.getMessage(), e);
+                return false;
+            }
+        });
+
+        logger.debug("EvalInList: listName={}, result={}", listName, result);
+        return result;
+    }
+
+    private String stripQuotes(String quotedString) {
+        if (quotedString.startsWith("'") && quotedString.endsWith("'")) {
+            return quotedString.substring(1, quotedString.length() - 1);
+        }
+        return quotedString;
+    }
+
+    /**
+     * Scoped visitor that handles property access with 'elem.' prefix.
+     * When a property like 'elem.field1' is accessed, it resolves to 'field1' from the current list item.
+     */
+    private static class ScopedVisitor extends Visitor {
+        private final Object currentItem;
+        private final Visitor parentVisitor;
+
+        public ScopedVisitor(Object currentItem, Visitor parentVisitor) {
+            // Use the current item as data context, preserve root and lists from parent
+            super(
+                currentItem instanceof Map ? (Map<String, ?>) currentItem : Map.of(),
+                parentVisitor.getLists(),
+                parentVisitor.getRoot()
+            );
+            this.currentItem = currentItem;
+            this.parentVisitor = parentVisitor;
+        }
+
+        @Override
+        public Object visit(org.antlr.v4.runtime.tree.ParseTree tree) {
+            // Intercept PropertyContext and ValidPropertyContext to handle 'elem' before normal dispatch
+            if (tree instanceof RuleFlowLanguageParser.PropertyContext) {
+                // PropertyContext wraps ValidPropertyContext, so extract and handle it
+                RuleFlowLanguageParser.PropertyContext propCtx = (RuleFlowLanguageParser.PropertyContext) tree;
+                return visitValidProperty(propCtx.validProperty());
+            }
+            if (tree instanceof RuleFlowLanguageParser.ValidPropertyContext) {
+                return visitValidProperty((RuleFlowLanguageParser.ValidPropertyContext) tree);
+            }
+            // For all other contexts, use super.visit() which will use this visitor's context
+            // but can access parent's lists and root through getLists() and getRoot()
+            return super.visit(tree);
+        }
+
+        @Override
+        public Object visitValidProperty(RuleFlowLanguageParser.ValidPropertyContext ctx) {
+            logger.debug("ScopedVisitor.visitValidProperty: property={}, K_ELEM.size={}, ID.size={}, nestedProperty={}, property={}, currentItem={}", 
+                ctx.getText(), ctx.K_ELEM().size(), ctx.ID().size(), ctx.nestedProperty != null, ctx.property != null, currentItem);
+            
+            // Check if this property starts with 'elem' token
+            boolean startsWithElem = ctx.K_ELEM().size() > 0 && "elem".equals(ctx.K_ELEM(0).getText());
+            logger.debug("ScopedVisitor.visitValidProperty: startsWithElem={}", startsWithElem);
+            
+            if (startsWithElem) {
+                int tokenCount = getTokenCount(ctx);
+                logger.debug("ScopedVisitor.visitValidProperty: tokenCount={}", tokenCount);
+                
+                // If just 'elem' (single token), return the current item itself
+                if (tokenCount == 1) {
+                    logger.debug("ScopedVisitor: 'elem' refers to current item: {}", currentItem);
+                    return currentItem;
+                }
+                
+                // Handle 'elem.field1' or 'elem.field1.field2' patterns
+                // Skip the first 'elem' token and resolve the rest from the current item
+                if (currentItem instanceof Map) {
+                    Map<String, ?> itemMap = (Map<String, ?>) currentItem;
+                    Object result = resolveNestedProperty(ctx, itemMap, 1); // Start from index 1 (skip 'elem')
+                    logger.debug("ScopedVisitor resolved nested property elem.*: {}", result);
+                    return result;
+                } else {
+                    throw new PropertyNotFoundException("Property 'elem." + getPropertyPath(ctx, 1) + "' cannot be found - item is not a map");
+                }
+            }
+            
+            // For simple properties (not starting with 'elem'), first try current item, then fall back to parent
+            if (ctx.property != null && currentItem instanceof Map) {
+                Map<String, ?> itemMap = (Map<String, ?>) currentItem;
+                String propertyName = getFirstTokenText(ctx);
+                if (itemMap.containsKey(propertyName)) {
+                    Object result = itemMap.get(propertyName);
+                    logger.debug("ScopedVisitor resolved simple property from item: {}={}", propertyName, result);
+                    return result;
+                }
+            }
+            
+            // Fall back to parent visitor's property resolution
+            logger.debug("ScopedVisitor falling back to parent visitor for property: {}", ctx.getText());
+            return parentVisitor.visit(ctx);
+        }
+
+        private String getFirstTokenText(RuleFlowLanguageParser.ValidPropertyContext ctx) {
+            // Check K_ELEM first (since it's more specific), then ID
+            if (ctx.K_ELEM().size() > 0) {
+                return ctx.K_ELEM(0).getText();
+            } else if (ctx.ID().size() > 0) {
+                return ctx.ID(0).getText();
+            }
+            return "";
+        }
+
+        private int getTokenCount(RuleFlowLanguageParser.ValidPropertyContext ctx) {
+            return ctx.ID().size() + ctx.K_ELEM().size();
+        }
+
+        @SuppressWarnings("unchecked")
+        private Object resolveNestedProperty(RuleFlowLanguageParser.ValidPropertyContext ctx, Map<String, ?> data, int startIndex) {
+            Map<String, ?> currentData = data;
+            var allTokens = getAllTokens(ctx);
+            logger.debug("ScopedVisitor.resolveNestedProperty: allTokens={}, startIndex={}, data={}", allTokens, startIndex, data);
+            
+            for (int i = startIndex; i < allTokens.size(); i++) {
+                String part = allTokens.get(i);
+                Object value = currentData.get(part);
+                logger.debug("ScopedVisitor.resolveNestedProperty: part={}, value={}, currentData={}", part, value, currentData);
+                
+                if (value == null) {
+                    throw new PropertyNotFoundException("Property 'elem." + getPropertyPath(ctx, startIndex) + "' cannot be found at '" + part + "'");
+                }
+                
+                if (i == allTokens.size() - 1) {
+                    // Last part, return the value
+                    return value;
+                } else if (value instanceof Map<?, ?>) {
+                    // Continue navigating nested maps
+                    currentData = (Map<String, ?>) value;
+                } else {
+                    // Not a map, cannot navigate further
+                    throw new PropertyNotFoundException("Property 'elem." + getPropertyPath(ctx, startIndex) + "' cannot be navigated - '" + part + "' is not a map");
+                }
+            }
+            
+            throw new PropertyNotFoundException("Property 'elem." + getPropertyPath(ctx, startIndex) + "' cannot be found");
+        }
+
+        private List<String> getAllTokens(RuleFlowLanguageParser.ValidPropertyContext ctx) {
+            List<String> tokens = new java.util.ArrayList<>();
+            // For nested properties, tokens appear in order: first token, DOT, second token, DOT, etc.
+            // We need to preserve the order as they appear in the parse tree
+            // K_ELEM tokens appear before ID tokens in the property path
+            int totalTokens = ctx.K_ELEM().size() + ctx.ID().size();
+            
+            // For elem.field1, we have: K_ELEM("elem") at index 0, ID("field1") at index 1
+            // So we add K_ELEM tokens first, then ID tokens
+            for (int i = 0; i < ctx.K_ELEM().size(); i++) {
+                tokens.add(ctx.K_ELEM(i).getText());
+            }
+            for (int i = 0; i < ctx.ID().size(); i++) {
+                tokens.add(ctx.ID(i).getText());
+            }
+            
+            return tokens;
+        }
+
+        private String getPropertyPath(RuleFlowLanguageParser.ValidPropertyContext ctx, int startIndex) {
+            var allTokens = getAllTokens(ctx);
+            StringBuilder path = new StringBuilder();
+            for (int i = startIndex; i < allTokens.size(); i++) {
+                if (i > startIndex) {
+                    path.append(".");
+                }
+                path.append(allTokens.get(i));
+            }
+            return path.toString();
+        }
+
+    }
+}
+
+

--- a/src/main/java/com/gatekeeperx/ruleflow/visitors/Visitor.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/visitors/Visitor.java
@@ -14,6 +14,7 @@ import com.gatekeeperx.ruleflow.evaluators.DateOperationContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.DateParseExprContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.DateValueContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.DayOfWeekContextEvaluator;
+import com.gatekeeperx.ruleflow.evaluators.EvalInListContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.GeoOperationContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.ListContextEvaluator;
 import com.gatekeeperx.ruleflow.evaluators.MathAddContextEvaluator;
@@ -106,6 +107,8 @@ public class Visitor extends RuleFlowLanguageBaseVisitor<Object> {
                 return new StringDistanceContextEvaluator().evaluateStringSimilarityScore((RuleFlowLanguageParser.StringSimilarityScoreContext) ctx, this);
             } else if (ctx instanceof RuleFlowLanguageParser.GeoOperationContext) {
                 return new GeoOperationContextEvaluator().evaluate((RuleFlowLanguageParser.GeoOperationContext) ctx, this);
+            } else if (ctx instanceof RuleFlowLanguageParser.EvalInListContext) {
+                return new EvalInListContextEvaluator().evaluate((RuleFlowLanguageParser.EvalInListContext) ctx, this);
             } else {
                 throw new IllegalArgumentException("Operation not supported: " + ctx.getClass());
             }

--- a/src/test/java/EvalInListTest.java
+++ b/src/test/java/EvalInListTest.java
@@ -1,0 +1,433 @@
+import com.gatekeeperx.ruleflow.Workflow;
+import com.gatekeeperx.ruleflow.vo.WorkflowResult;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class EvalInListTest {
+
+    @Test
+    public void testEvalInListBasicMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "other"),
+                Map.of("field1", "test"),
+                Map.of("field1", "another")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListNoMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "default", "default", "allow");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "other"),
+                Map.of("field1", "another"),
+                Map.of("field1", "different")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListNestedProperty() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1.field2 = 'value') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", Map.of("field2", "other")),
+                Map.of("field1", Map.of("field2", "value")),
+                Map.of("field1", Map.of("field2", "another"))
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithComparison() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'high_value' evalInList('items', elem.price > 100) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "high_value", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "items", List.of(
+                Map.of("price", 50),
+                Map.of("price", 150),
+                Map.of("price", 75)
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithAndCondition() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test' AND elem.field2 = 'value') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "test", "field2", "other"),
+                Map.of("field1", "test", "field2", "value"),
+                Map.of("field1", "other", "field2", "value")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithOrCondition() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test' OR elem.field1 = 'other') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "different"),
+                Map.of("field1", "test"),
+                Map.of("field1", "another")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithNotEquals() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 <> 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "test"),
+                Map.of("field1", "test"),
+                Map.of("field1", "other")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithLessThan() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'low_value' evalInList('items', elem.price < 50) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "low_value", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "items", List.of(
+                Map.of("price", 100),
+                Map.of("price", 30),
+                Map.of("price", 75)
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithGreaterThanOrEqual() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'high_value' evalInList('items', elem.price >= 100) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "high_value", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "items", List.of(
+                Map.of("price", 50),
+                Map.of("price", 100),
+                Map.of("price", 75)
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithParentContextAccess() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = user.id) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(
+            "user", Map.of("id", "test123")
+        ), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "other"),
+                Map.of("field1", "test123"),
+                Map.of("field1", "another")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListMissingList() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('nonexistent', elem.field1 = 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "default", "default", "allow");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of());
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListEmptyList() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "default", "default", "allow");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of()
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListComplexPredicate() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test' AND (elem.field2 > 100 OR elem.field3 = 'active')) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "test", "field2", 50, "field3", "inactive"),
+                Map.of("field1", "test", "field2", 150, "field3", "inactive"),
+                Map.of("field1", "other", "field2", 200, "field3", "active")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithStringContains() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 contains 'test') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "other"),
+                Map.of("field1", "testvalue"),
+                Map.of("field1", "another")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithMultipleFields() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'test' AND elem.field2 = 'value' AND elem.field3 = 'active') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "test", "field2", "value", "field3", "inactive"),
+                Map.of("field1", "test", "field2", "value", "field3", "active"),
+                Map.of("field1", "other", "field2", "value", "field3", "active")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListCaseInsensitive() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('blacklist', elem.field1 = 'TEST') return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "blacklist", List.of(
+                Map.of("field1", "other"),
+                Map.of("field1", "TEST"),
+                Map.of("field1", "another")
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithNumericComparison() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('items', elem.quantity * elem.price > 1000) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of(), Map.of(
+            "items", List.of(
+                Map.of("quantity", 5, "price", 100),
+                Map.of("quantity", 10, "price", 150),
+                Map.of("quantity", 2, "price", 50)
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testEvalInListWithTransactionEmailAndDateComparison() {
+        // Test combining parent context access (transaction.email), date function (now()), 
+        // and list element properties (elem.fieldName1, elem.endDate)
+        // This tests that elem properties work together with parent context properties and date functions
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'blocked' evalInList('aList', elem.fieldName1 = transaction.email AND date(elem.endDate) >= date(now())) return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "blocked", "block");
+
+        // Use ISO date strings (yyyy-MM-dd format) as the date() function expects strings
+        // Format dates as yyyy-MM-dd which is what date() function expects
+        LocalDateTime now = LocalDateTime.now();
+        String pastDate = now.minusYears(3).toLocalDate().format(java.time.format.DateTimeFormatter.ISO_DATE);
+        String futureDate = now.plusYears(3).toLocalDate().format(java.time.format.DateTimeFormatter.ISO_DATE);
+        String currentDate = now.toLocalDate().format(java.time.format.DateTimeFormatter.ISO_DATE);
+
+        WorkflowResult result = ruleEngine.evaluate(Map.of(
+            "transaction", Map.of("email", "elem1")
+        ), Map.of(
+            "aList", List.of(
+                Map.of("fieldName1", "other", "endDate", currentDate),      // Wrong email
+                Map.of("fieldName1", "elem1", "endDate", pastDate),         // Right email but past date (should not match)
+                Map.of("fieldName1", "elem1", "endDate", futureDate)        // Matches email AND future date (should match)
+            )
+        ));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+}
+


### PR DESCRIPTION
This commit introduces a new evalInList function that allows evaluating predicates over list elements, with support for accessing current list item properties via the 'elem' keyword.

Features:
- New evalInList('listName', predicate) function that returns true if any element in the list matches the predicate
- New 'elem' keyword for referencing the current list element within evalInList predicates
- Support for nested properties: elem.field1, elem.field1.field2
- Support for combining elem properties with parent context properties and date functions in complex predicates

Grammar Changes:
- Added K_EVAL_IN_LIST token and evalInList expression rule
- Added K_ELEM token for list element references
- Updated validProperty rule to allow K_ELEM in property paths

Implementation:
- Created EvalInListContextEvaluator to handle evalInList evaluation
- Implemented ScopedVisitor inner class to provide scoped context for elem resolution within predicates
- Updated ValidPropertyContextEvaluator to handle K_ELEM tokens
- Fixed DateValueContextEvaluator to use visitor.visit() instead of directly instantiating ValidPropertyContextEvaluator, ensuring ScopedVisitor can intercept elem properties in date functions
- Updated Visitor to dispatch EvalInListContext to the new evaluator

Testing:
- Added comprehensive test suite with 18 test cases covering:
  * Basic matching and non-matching scenarios
  * Nested property access (elem.field1.field2)
  * Comparison operators (equals, not equals, greater than, less than)
  * Logical operators (AND, OR)
  * String operations (contains)
  * Numeric comparisons
  * Edge cases (empty lists, missing lists)
  * Parent context access within predicates
  * Complex predicates combining elem, parent context, and date functions

Documentation:
- Added CHANGELOG.md documenting the new feature

All tests passing (158 tests, 0 failures)