### PR TITLE
Allow comparisons between number and string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.gatekeeperx</groupId>
     <artifactId>ruleflow</artifactId>
     <name>ruleflow</name>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/gatekeeperx/ruleflow/evaluators/ComparatorContextEvaluator.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/evaluators/ComparatorContextEvaluator.java
@@ -27,6 +27,10 @@ public class ComparatorContextEvaluator implements ContextEvaluator<RuleFlowLang
             result = compareBooleans(ctx.op, (Boolean) left, (Boolean) right);
         } else if (left instanceof java.time.ZonedDateTime && right instanceof java.time.ZonedDateTime) {
             result = compareZonedDateTimes(ctx.op, (java.time.ZonedDateTime) left, (java.time.ZonedDateTime) right);
+        } else if (left instanceof String && right instanceof Number) {
+            result = compareMixedStringNumber(ctx.op, (String) left, (Number) right, true);
+        } else if (left instanceof Number && right instanceof String) {
+            result = compareMixedStringNumber(ctx.op, (String) right, (Number) left, false);
         } else if (left instanceof Comparable<?> && right instanceof Comparable<?>) {
             result = compareComparables(ctx.op, (Comparable<?>) left, (Comparable<?>) right);
         } else {
@@ -79,6 +83,25 @@ public class ComparatorContextEvaluator implements ContextEvaluator<RuleFlowLang
             case RuleFlowLanguageParser.GT_EQ -> comparisonResult >= 0;
             default -> throw new RuntimeException("Invalid condition " + operator.getText());
         };
+    }
+
+    /**
+     * Handles comparisons where one operand is a String and the other is a Number.
+     * Tries to parse the string as a number for numeric comparison; if the string
+     * is non-numeric, only NOT_EQ returns true (they are clearly different values).
+     *
+     * @param stringIsLeft true when the String was the left operand in the original expression
+     */
+    private Boolean compareMixedStringNumber(Token operator, String str, Number num, boolean stringIsLeft) {
+        try {
+            Double parsedStr = Double.valueOf(str);
+            Double numValue = num.doubleValue();
+            return stringIsLeft
+                ? compareValues(operator, Double::compareTo, parsedStr, numValue)
+                : compareValues(operator, Double::compareTo, numValue, parsedStr);
+        } catch (NumberFormatException e) {
+            return operator.getType() == RuleFlowLanguageParser.NOT_EQ;
+        }
     }
 
     private Boolean compareZonedDateTimes(Token operator, java.time.ZonedDateTime left, java.time.ZonedDateTime right) {

--- a/src/test/java/CompareTest.java
+++ b/src/test/java/CompareTest.java
@@ -133,4 +133,124 @@ class CompareTest {
             .anyMatch(warning -> warning.equals("There is a comparison between different dataTypes in rule comparison")),
             "Should contain warning about type comparison in rule 'comparison'");
     }
+
+    @Test
+    public void givenNumberWhenOperatingEqualsOperationMustGoOk() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_is_equals' x  = 3456 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_is_equals", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "3456"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenStringValueWhenComparedWithNumberLtMustGoOk() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_lt' x < 100 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_lt", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "50"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenStringValueWhenComparedWithNumberGtMustGoOk() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_gt' x > 100 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_gt", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "200"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenStringValueWhenComparedWithNumberNotEqualMustGoOk() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_ne' x <> 100 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_ne", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "999"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenNonNumericStringWhenComparedWithNumberEqualsMustFallToDefault() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_eq' x = 5967 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "not_a_number"));
+
+        Assertions.assertEquals("allow", result.getResult());
+        Assertions.assertEquals("default", result.getRule());
+    }
+
+    @Test
+    public void givenNonNumericStringWhenComparedWithNumberNotEqualMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_ne' x <> 5967 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_ne", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "not_a_number"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenDecimalStringWhenComparedWithNumberMustGoOk() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'x_eq' x = 99.5 return block
+                default allow
+            end
+        """;
+
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "x_eq", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("x", "99.5"));
+
+        Assertions.assertEquals(expectedResult, result);
+    }
+
 }


### PR DESCRIPTION
## Allow comparisons between String and Number types

When rule definitions use unquoted numeric literals (e.g. `x = 3456`) and the request data provides the value as a String (e.g. `"3456"`), the comparator threw a `TypeComparisonException` because there was no branch handling mixed String/Number operands. This was also observed in production with errors like:

> `TypeComparisonException: Cannot compare non-numeric string with number: vs 5967.0`

This PR adds automatic type coercion in `ComparatorContextEvaluator` so that String values are parsed as numbers when compared against numeric literals. All comparison operators (`=`, `==`, `<>`, `<`, `<=`, `>`, `>=`) are supported. If the String is not a valid number, equality returns `false` and `<>` returns `true` instead of throwing.

### Changes

- **`ComparatorContextEvaluator.java`** - Added `compareMixedStringNumber` method with new dispatch branches for `(String, Number)` and `(Number, String)` type combinations
- **`CompareTest.java`** - Added 7 integration tests covering: equality, less-than, greater-than, not-equal, non-numeric string fallback, and decimal comparison
- **`pom.xml`** - Version bump `0.10.1` -> `0.10.2`

### Test plan

- [x] `x = 3456` with `"3456"` (String) matches
- [x] `x < 100` with `"50"` matches
- [x] `x > 100` with `"200"` matches
- [x] `x <> 100` with `"999"` matches
- [x] `x = 5967` with `"not_a_number"` falls to default (no exception)
- [x] `x <> 5967` with `"not_a_number"` matches (clearly not equal)
- [x] `x = 99.5` with `"99.5"` matches (decimal)
- [x] All 148 existing tests pass