### PR TITLE
New Time Functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.gatekeeperx</groupId>
     <artifactId>ruleflow</artifactId>
     <name>ruleflow</name>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/antlr4/com/gatekeeperx/ruleflow/RuleFlowLanguage.g4
+++ b/src/main/antlr4/com/gatekeeperx/ruleflow/RuleFlowLanguage.g4
@@ -93,6 +93,7 @@ dateExpr: DATE_DIFF L_PAREN left=dateValue COMMA right=dateValue COMMA (HOUR | D
     | op=K_NOW L_PAREN R_PAREN #now
     | op=K_DATE_ADD L_PAREN date=dateValue COMMA amount=expr COMMA unit=timeUnit R_PAREN #dateAdd
     | op=K_DATE_SUBTRACT L_PAREN date=dateValue COMMA amount=expr COMMA unit=timeUnit R_PAREN #dateSubtract
+    | op=(K_YEAR | K_MONTH | DAY | HOUR | MINUTE) L_PAREN left=dateValue R_PAREN #dateComponent
     ;
 
 propertyTuple: L_PAREN validProperty (COMMA validProperty)* R_PAREN;
@@ -189,6 +190,8 @@ K_DATE: D A T E;
 K_DATETIME: D A T E T I M E;
 K_DATE_ADD: D A T E '_' A D D;
 K_DATE_SUBTRACT: D A T E '_' S U B T R A C T;
+K_YEAR: Y E A R;
+K_MONTH: M O N T H;
 K_SET: S E T;
 K_CONTINUE: C O N T I N U E;
 

--- a/src/main/java/com/gatekeeperx/ruleflow/evaluators/DateComponentContextEvaluator.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/evaluators/DateComponentContextEvaluator.java
@@ -1,0 +1,45 @@
+package com.gatekeeperx.ruleflow.evaluators;
+
+import com.gatekeeperx.ruleflow.RuleFlowLanguageLexer;
+import com.gatekeeperx.ruleflow.RuleFlowLanguageParser;
+import com.gatekeeperx.ruleflow.visitors.Visitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+
+public class DateComponentContextEvaluator implements ContextEvaluator<RuleFlowLanguageParser.DateComponentContext> {
+    private static final Logger logger = LoggerFactory.getLogger(DateComponentContextEvaluator.class);
+
+    @Override
+    public Object evaluate(RuleFlowLanguageParser.DateComponentContext ctx, Visitor visitor) {
+        ZonedDateTime value = (ZonedDateTime) new DateValueContextEvaluator().evaluate(ctx.left, visitor);
+
+        if (value == null) {
+            throw new IllegalArgumentException("Parameter value not supported: " + ctx.left.getText());
+        }
+
+        long result;
+        switch (ctx.op.getType()) {
+            case RuleFlowLanguageLexer.K_YEAR:
+                result = value.getYear();
+                break;
+            case RuleFlowLanguageLexer.K_MONTH:
+                result = value.getMonthValue();
+                break;
+            case RuleFlowLanguageLexer.DAY:
+                result = value.getDayOfMonth();
+                break;
+            case RuleFlowLanguageLexer.HOUR:
+                result = value.getHour();
+                break;
+            case RuleFlowLanguageLexer.MINUTE:
+                result = value.getMinute();
+                break;
+            default:
+                throw new IllegalArgumentException("Operation not supported: " + ctx.op.getText());
+        }
+        logger.debug("DateComponent: op={}, dateValue={}, result={}", ctx.op.getText(), ctx.left.getText(), result);
+        return result;
+    }
+}

--- a/src/main/java/com/gatekeeperx/ruleflow/visitors/Visitor.java
+++ b/src/main/java/com/gatekeeperx/ruleflow/visitors/Visitor.java
@@ -101,6 +101,8 @@ public class Visitor extends RuleFlowLanguageBaseVisitor<Object> {
                 return new BinaryOrContextEvaluator().evaluate((RuleFlowLanguageParser.BinaryOrContext) ctx, this);
             } else if (ctx instanceof RuleFlowLanguageParser.DayOfWeekContext) {
                 return new DayOfWeekContextEvaluator().evaluate((RuleFlowLanguageParser.DayOfWeekContext) ctx, this);
+            } else if (ctx instanceof RuleFlowLanguageParser.DateComponentContext) {
+                return new com.gatekeeperx.ruleflow.evaluators.DateComponentContextEvaluator().evaluate((RuleFlowLanguageParser.DateComponentContext) ctx, this);
             } else if (ctx instanceof RuleFlowLanguageParser.RegexlikeContext) {
                 return new RegexContextEvaluator().evaluate((RuleFlowLanguageParser.RegexlikeContext) ctx, this);
             } else if (ctx instanceof RuleFlowLanguageParser.DateValueContext) {

--- a/src/test/java/DateTimeTest.java
+++ b/src/test/java/DateTimeTest.java
@@ -367,6 +367,125 @@ class DateTimeTest {
     }
 
     @Test
+    public void givenYearExtractionWithDateTimeMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'year_extract' year('2024-06-01T12:30Z') = 2024 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "year_extract", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenMonthExtractionWithDateTimeMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'month_extract' month('2024-06-01T12:30Z') = 6 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "month_extract", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenDayExtractionWithDateTimeMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'day_extract' day('2024-06-01T12:30Z') = 1 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "day_extract", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenHourExtractionWithDateTimeMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'hour_extract' hour('2024-06-01T12:30Z') = 12 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "hour_extract", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenMinuteExtractionWithDateTimeMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'minute_extract' minute('2024-06-01T12:30Z') = 30 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "minute_extract", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenComponentExtractionWithPropertyMustMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'year_prop' year(order_date) = 2024 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "year_prop", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of("order_date", "2024-06-01T12:30Z"));
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenHourExtractionWithDateOnlyStringMustReturnZero() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'hour_date_only' hour('2020-03-01') = 0 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult expectedResult = new WorkflowResult("test", "dummy", "hour_date_only", "block");
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void givenComponentExtractionWithInvalidStringMustNotMatch() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'hour_invalid' hour('not-a-date') = 0 return block
+                default allow
+            end
+        """;
+        Workflow ruleEngine = new Workflow(workflow);
+        WorkflowResult result = ruleEngine.evaluate(Map.of());
+        Assertions.assertNotEquals("block", result.getResult());
+    }
+
+    @Test
     public void givenDateAndDateTimeWhenComparingMustMatch() {
         String workflow = """
             workflow 'test'


### PR DESCRIPTION
 ## Summary

  Adds date-component extraction functions to the RuleFlow DSL. Previously the language could parse, compare, add/subtract, and diff dates, but there was no way to pull out an individual field (year, month, etc.) from a date or
  datetime.

  ## New functions

  | Function | Returns |
  |---|---|
  | `year(x)` | full year, e.g. `2024` |
  | `month(x)` | month `1`–`12` |
  | `day(x)` | day of month |
  | `hour(x)` | hour `0`–`23` |
  | `minute(x)` | minute `0`–`59` |

  Each accepts a `dateValue` — a string literal, a property, or `now()` — and returns a numeric (`long`) value, so numeric comparisons work directly:

  ```
  year('2024-06-01T12:30Z') = 2024
  month(order_date) = 6
  hour(now()) >= 9
  ```
  
  ## Behavior notes

  - **Date-only inputs** (e.g. `'2020-03-01'`) are valid: they parse to start-of-day, so `hour(...)` and `minute(...)` return `0`, while `year`/`month`/`day` are correct.
  - **Unparseable strings** (e.g. `'not-a-date'`) throw `Invalid date/datetime`, which the engine catches — the rule does not match and evaluation falls through to `default`.
  - `day`, `hour`, and `minute` were already reserved keywords (used by `date_add`/`date_diff`); `year` and `month` are now reserved as well, so they can't be used as bare property names.

  ## Changes

  - `RuleFlowLanguage.g4` — new `#dateComponent` alternative under `dateExpr`; reuses the existing `DAY`/`HOUR`/`MINUTE` tokens and adds `K_YEAR`/`K_MONTH` keyword tokens.
  - `DateComponentContextEvaluator.java` — new evaluator, switches on the op token (mirrors `DayOfWeekContextEvaluator`).
  - `Visitor.java` — one dispatch branch for `DateComponentContext`.
  - `DateTimeTest.java` — 8 new tests covering each component, property inputs, the date-only edge case, and the invalid-string fallthrough.
  - `pom.xml` — version bump `0.15.0` → `0.16.0`.

  ## Testing

  Full suite green: **248 tests, 0 failures**.